### PR TITLE
Added a fix that'll skip the optional fields from validating

### DIFF
--- a/src/Enums/Rule.php
+++ b/src/Enums/Rule.php
@@ -31,7 +31,6 @@ enum Rule: string
     case string             =   TypeStr::class;
     case boolean            =   TypeBool::class;
     case integer            =   TypeInt::class;
-    case optional           =   'optional';
     case required           =   Required::class;
     case required_if        =   RequiredIf::class;
     case required_with      =   RequiredWith::class;
@@ -52,5 +51,15 @@ enum Rule: string
         }
 
         return constant("self::{$name}")->value;
+    }
+
+    /**
+     * Get the names of the cases that point to the constraint rules.
+     *
+     * @return array<int, string>
+     */
+    public static function getConstraintRulesCases(): array
+    {
+        return ['required'];
     }
 }

--- a/src/Utils/Arr.php
+++ b/src/Utils/Arr.php
@@ -27,7 +27,7 @@ function array_to_dot(array $arr): array
     foreach ($arr as $key => $value) {
         $nestedKeys[$arr->getDepth()] = $key;
 
-        if (is_array($value)) {
+        if (is_array($value) && !empty($value)) {
             continue;
         }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -20,7 +20,8 @@ final class ValidatorTest extends TestCase
     public function testRequiredRule()
     {
         $validator = new Validator([], [
-            'abc' => 'required'
+            'abc' => 'required',
+            'xyz' => 'string'
         ]);
 
         $validator->validate();
@@ -47,12 +48,10 @@ final class ValidatorTest extends TestCase
     public function testStringRule()
     {
         $validator = new Validator([
-            'abc' => [],
-            'xyz' => []
+            'abc'   =>  [],
         ], [
-            'abc' => 'string',
-            'xyz' => 'required|string',
-            'pqr' => 'optional|string'
+            'abc'   =>  'string',
+            'xyz'   =>  'required|string',
         ]);
 
         $validator->validate();


### PR DESCRIPTION
    - Removed the validation rule 'optional'.
    - Added a logic which skips the optional field [Not present OR is Null]

This commit fixes the issue with the optional fields still being validated. A field will be considered optional if the field is either not present OR is null. The validation of such field will be skipped in its entirety.